### PR TITLE
Feat: Added Spam Prevention

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -137,16 +137,17 @@ async function main() {
 		client.on('messageCreate', async message => {
 			// Only responds to members, any users with higher permissions are safe
 			if (!await hasPermissionLevel(message.member as GuildMember, PermissionLevel.BETA_TESTER)) {
-				const response = await messageNeedsResponse(message);
-				if (response) {
-					message.reply(response);
-				}
 
 				const spam_prevention = await messageIsSpam(message);
 				if (spam_prevention){
 					message.delete();
 					message.member?.timeout(config.options.timeoutTime, config.messages.timeoutSpamReason);
 					log.userSpamResponse(client, message);
+				}
+				
+				const response = await messageNeedsResponse(message);
+				if (response) {
+					message.reply(response);
 				}
 			}
 		});

--- a/src/main.ts
+++ b/src/main.ts
@@ -144,6 +144,7 @@ async function main() {
 
 				const spamPrevention = await messageIsSpam(message);
 				if(spamPrevention){
+					message.delete();
 					message.member?.timeout(config.options.timeoutTime, config.messages.timeoutSpamReason);
 					(client.channels.cache.get(config.channels.modChannel) as TextChannel).send("User <@"+message.author.id+"> Has send more than "+config.options.maxMentions+" mentions and therefore has been timed out for "+config.options.timeoutTime+" milliseconds.");
 				}

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,11 +142,11 @@ async function main() {
 					message.reply(response);
 				}
 
-				const spamPrevention = await messageIsSpam(message);
-				if(spamPrevention){
+				const spam_prevention = await messageIsSpam(message);
+				if(spam_prevention){
 					message.delete();
 					message.member?.timeout(config.options.timeoutTime, config.messages.timeoutSpamReason);
-					(client.channels.cache.get(config.channels.modChannel) as TextChannel).send("User <@"+message.author.id+"> Has send more than "+config.options.maxMentions+" mentions and therefore has been timed out for "+config.options.timeoutTime+" milliseconds.");
+					log.userSpamResponse(client, message);
 				}
 			}
 		});

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,10 +141,10 @@ async function main() {
 				if (response) {
 					message.reply(response);
 				}
-				
+
 				const spamPrevention = await messageIsSpam(message);
 				if(spamPrevention){
-					message.member?.timeout(config.options.timeoutTime, config.messages.timeoutSpamMessage);
+					message.member?.timeout(config.options.timeoutTime, config.messages.timeoutSpamReason);
 					(client.channels.cache.get(config.channels.modChannel) as TextChannel).send("User <@"+message.author.id+"> Has send more than "+config.options.maxMentions+" mentions and therefore has been timed out for "+config.options.timeoutTime+" milliseconds.");
 				}
 			}

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,13 +135,15 @@ async function main() {
 	// Listen for messages to respond to
 	if (config.options.autorespond) {
 		client.on('messageCreate', async message => {
+			// If the bot is DMed, we return, we don't care about DMs.
+			if(message.channel.isDMBased()) return;
 			// Only responds to members, any users with higher permissions are safe
 			if (!await hasPermissionLevel(message.member as GuildMember, PermissionLevel.BETA_TESTER)) {
 
 				const spam_prevention = await messageIsSpam(message);
 				if (spam_prevention){
 					message.delete();
-					message.member?.timeout(config.options.timeoutTime, config.messages.timeoutSpamReason);
+					message.member?.timeout(config.options.timeout_time, config.messages.timeout_spam_reason);
 					log.userSpamResponse(client, message);
 				}
 				

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
-import { ActivityType, Client, Collection, GuildMember, IntentsBitField, Partials } from 'discord.js';
+import { ActivityType, Client, Collection, GuildMember, IntentsBitField, Partials, TextChannel } from 'discord.js';
 import { REST } from '@discordjs/rest';
 import { Routes } from 'discord-api-types/v9';
 import fs from 'fs';
 import * as log from './utils/log';
 import { hasPermissionLevel, PermissionLevel } from './utils/permissions';
 import { messageNeedsResponse } from './utils/autorespond';
+import { messageIsSpam } from './utils/spamprevent';
 import { Command } from './types/command';
 
 import * as config from './config.json';
@@ -139,6 +140,12 @@ async function main() {
 				const response = await messageNeedsResponse(message);
 				if (response) {
 					message.reply(response);
+				}
+				
+				const spamPrevention = await messageIsSpam(message);
+				if(spamPrevention){
+					message.member?.timeout(config.options.timeoutTime, config.messages.timeoutSpamMessage);
+					(client.channels.cache.get(config.channels.modChannel) as TextChannel).send("User <@"+message.author.id+"> Has send more than "+config.options.maxMentions+" mentions and therefore has been timed out for "+config.options.timeoutTime+" milliseconds.");
 				}
 			}
 		});

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -48,6 +48,10 @@ export function userBanned(client: Client, ban: GuildBan) {
 	message(client, 'BAN', LogLevelColor.IMPORTANT, `**${ban.user.username}#${ban.user.discriminator}** was banned`, ban.user.avatarURL());
 }
 
+export function userSpamResponse(client: Client, msg: Message<boolean> | PartialMessage){
+	message(client,"TIMEOUT",LogLevelColor.IMPORTANT,"User <@"+msg.author?.id+"> Has send more than "+config.options.maxMentions+" mentions and therefore has been timed out for "+config.options.timeoutTime+" milliseconds.");
+}
+
 export function messageDeleted(client: Client, msg: Message<boolean> | PartialMessage) {
 	if (msg.author?.bot || !msg.author?.username) return undefined;
 	if (msg.cleanContent) {

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -49,7 +49,7 @@ export function userBanned(client: Client, ban: GuildBan) {
 }
 
 export function userSpamResponse(client: Client, msg: Message<boolean> | PartialMessage){
-	message(client,"TIMEOUT",LogLevelColor.IMPORTANT,"User <@"+msg.author?.id+"> Has send more than "+config.options.maxMentions+" mentions and therefore has been timed out for "+config.options.timeoutTime+" milliseconds.");
+	message(client,"TIMEOUT",LogLevelColor.IMPORTANT,"User <@"+msg.author?.id+"> Has send more than "+config.options.max_mentions+" mentions and therefore has been timed out for "+config.options.timeout_time+" milliseconds.");
 }
 
 export function messageDeleted(client: Client, msg: Message<boolean> | PartialMessage) {

--- a/src/utils/spamprevent.ts
+++ b/src/utils/spamprevent.ts
@@ -2,10 +2,6 @@ import { Message } from 'discord.js';
 
 import * as config from '../config.json';
 
-export async function messageIsSpam(msg: Message<boolean>): Promise<boolean | undefined> {
-
-    if (msg.mentions.users.size > config.options.maxMentions)
-        return true;
-    return false;
-    
+export async function messageIsSpam(msg: Message<boolean>) {
+    return (msg.mentions.users.size > config.options.maxMentions);
 }

--- a/src/utils/spamprevent.ts
+++ b/src/utils/spamprevent.ts
@@ -1,0 +1,11 @@
+import { Message } from 'discord.js';
+
+import * as config from '../config.json';
+
+export async function messageIsSpam(msg: Message<boolean>): Promise<boolean | undefined> {
+
+    if(msg.mentions.users.size > config.options.maxMentions)
+        return true;
+    return false;
+    
+}

--- a/src/utils/spamprevent.ts
+++ b/src/utils/spamprevent.ts
@@ -3,5 +3,5 @@ import { Message } from 'discord.js';
 import * as config from '../config.json';
 
 export async function messageIsSpam(msg: Message<boolean>) {
-    return (msg.mentions.users.size > config.options.maxMentions);
+    return (msg.mentions.users.size > config.options.max_mentions);
 }


### PR DESCRIPTION
Added spam prevention for mass pinging users.
Currently only supports spam reporting/timeouting users that exceed the maximum amount of mentions per message allowed.

newly added config variables:
```js
 config.options.max_mentions //Number: the maximum amount of mentions a user is allowed to use in 1 message before triggering the spam filter.
 config.options.timeout_time //Number: the amount of time the user is timed out.
```

I haven't had the chance to test this because setting up a config is extremely confusing but I made sure to triple check the code and will make changes if any issues arise.