### PR TITLE
feat: added /getuserid command that replies to the message of the author their user id

### DIFF
--- a/src/commands/guild/getuserid.ts
+++ b/src/commands/guild/getuserid.ts
@@ -1,0 +1,20 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { CommandInteraction } from "discord.js";
+import { Command } from "../../types/command";
+import { PermissionLevel } from "../../utils/permissions";
+
+const GetUserID: Command = {
+    permissionLevel: PermissionLevel.MEMBER,
+
+    data: new SlashCommandBuilder()
+        .setName("getuserid")
+        .setDescription("Gets the user ID of the user who typed the command"),
+
+    async execute(interaction: CommandInteraction) {
+        return interaction.reply({
+            content: `Your user ID is ${interaction.user.id}`,
+            ephemeral: true,
+        });
+    },
+};
+export default GetUserID;


### PR DESCRIPTION
Allows a user to get their user id. Can be useful for always matching the user of beta applications, even when they change their username or discriminator