### PR TITLE
Fix pluralkit integration not working

### DIFF
--- a/src/commands/guild/log.ts
+++ b/src/commands/guild/log.ts
@@ -1,4 +1,4 @@
-import { ActionRowBuilder, ChannelType, CommandInteraction, EmbedBuilder, SelectMenuOptionBuilder, SlashCommandBuilder, StringSelectMenuBuilder } from 'discord.js';
+import { ActionRowBuilder, ChannelType, CommandInteraction, EmbedBuilder, SelectMenuOptionBuilder, SlashCommandBuilder, SelectMenuBuilder } from 'discord.js';
 import fs from 'fs';
 import readline from 'readline';
 import events from 'events';
@@ -74,9 +74,9 @@ const Log: Command = {
 		}
 
 		case 'options': {
-			const selectMenu = new ActionRowBuilder<StringSelectMenuBuilder>()
+			const selectMenu = new ActionRowBuilder<SelectMenuBuilder>()
 				.addComponents(
-					new StringSelectMenuBuilder()
+					new SelectMenuBuilder()
 						.setCustomId('log_options')
 						.setPlaceholder('Logging options')
 						.addOptions(

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,8 +1,17 @@
-import { ButtonInteraction, Client, ClientOptions, Collection, InteractionResponse, Message, ModalSubmitInteraction, StringSelectMenuInteraction } from 'discord.js';
+import {
+	ButtonInteraction,
+	Client,
+	ClientOptions,
+	Collection,
+	InteractionResponse,
+	Message,
+	ModalSubmitInteraction,
+	SelectMenuInteraction
+} from 'discord.js';
 import { CommandBase } from './interaction';
 
 type ButtonCallback = (interaction: ButtonInteraction) => Promise<void | Message<boolean> | InteractionResponse<boolean>>;
-type SelectMenuCallback = (interaction: StringSelectMenuInteraction) => Promise<void | Message<boolean> | InteractionResponse<boolean>>;
+type SelectMenuCallback = (interaction: SelectMenuInteraction) => Promise<void | Message<boolean> | InteractionResponse<boolean>>;
 type ModalCallback = (interaction: ModalSubmitInteraction) => void;
 
 export class Callbacks {
@@ -38,7 +47,7 @@ export class Callbacks {
 		return this.#buttonCallbacks.get(buttonID)?.(interaction);
 	}
 
-	runSelectMenuCallback(menuID: string, interaction: StringSelectMenuInteraction) {
+	runSelectMenuCallback(menuID: string, interaction: SelectMenuInteraction) {
 		return this.#menuCallbacks.get(menuID)?.(interaction);
 	}
 

--- a/src/utils/pluralkit.ts
+++ b/src/utils/pluralkit.ts
@@ -8,7 +8,7 @@ const cache: string[] = [];
 export async function isSystemMessage(message: Message | PartialMessage) {
 	try {
 		// simple fetch to check if the message was proxied
-		return (await (await fetch(`https://api.pluralkit.me/v2/messages/${message.id}`)).text()).includes('Message not found');
+		return (await fetch(`https://api.pluralkit.me/v2/messages/${message.id}`)).status != 404;
 	} catch (e) {
 		return false;
 	}


### PR DESCRIPTION
_it was a single line, like always_

ender had done a woopsie, trying to find a string in the response, when she could have just used the response's status code

~ Firmament