### PR TITLE
Fix pluralkit integration not working

### DIFF
--- a/src/utils/pluralkit.ts
+++ b/src/utils/pluralkit.ts
@@ -8,7 +8,7 @@ const cache: string[] = [];
 export async function isSystemMessage(message: Message | PartialMessage) {
 	try {
 		// simple fetch to check if the message was proxied
-		return (await (await fetch(`https://api.pluralkit.me/v2/messages/${message.id}`)).text()).includes('Message not found');
+		return (await fetch(`https://api.pluralkit.me/v2/messages/${message.id}`)).status != 404;
 	} catch (e) {
 		return false;
 	}


### PR DESCRIPTION
it was a single line, like always

ender had done a woopsie, trying to find a string in the response, when she could have just used the response's status code

~ Firmament